### PR TITLE
Documentation updates to support other Karavi Observability repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You may obtain a copy of the License at
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](docs/CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/github/license/dell/karavi-observability)](LICENSE)
+[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/dell/karavi-observability?include_prereleases&label=latest&style=flat-square)](https://github.com/dell/karavi-observability/releases/latest)
 
 Karavi Observability is part of the [Karavi](https://github.com/dell/karavi) open source suite of Kubernetes storage enablers for Dell EMC products, providing standardized approaches for storage observability. Karavi Observability consists of several services, each of which is contained in a separate repository. This repository will be the hub for all things Karavi Observability. [Issues](https://github.com/dell/karavi-observability/issues) against any of the Karavi Observability services need to be created here.
 
@@ -34,7 +35,7 @@ Please see [Getting Started Guide](./docs/GETTING_STARTED_GUIDE.md) for informat
 
 ## Support
 
-Don’t hesitate to ask! Contact the team and community on [our support](./docs/SUPPORT.md).
+Don’t hesitate to ask! Contact the team and community on our [support](./docs/SUPPORT.md) page.
 Open an issue if you found a bug on [Github Issues](https://github.com/dell/karavi-observability/issues).
 
 ## Versioning

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,33 @@
+<!--
+Copyright (c) 2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Branching Strategy
+
+This repository will use a release branching strategy.  Maintainers will create a release branch for a future release and all changes related to that release will be made on that branch.  When changes for a release are complete, the release branch is merged into the main branch after being approved as part of a pull request.
+
+When contributing to other Karavi Observability repositories, please follow the documentation in those repositories as the branching strategy may differ.
+
+## Branch Naming Convention
+
+The only type of branch that should be created in this repository is a release branch.  Release branches should follow the naming convention below.
+
+|  Branch Type |  Example                          |  Comment                                  |
+|--------------|-----------------------------------|-------------------------------------------|
+|  main        |  main                             |                                           |
+|  Release     |  release-1.0                      |  hotfix: release-1.1 patch: release-1.0.1 |
+
+## Steps for working on a release branch
+
+1. Fork the repository.
+2. Create a branch off of the release branch. The branch name should follow [branch naming convention](#branch-naming-convention).
+3. Make your changes and commit them to your branch.
+4. If other code changes have merged into the upstream release branch, perform a rebase of those changes into your branch.
+5. Open a [pull request](#pull-requests) between your branch and the upstream release branch.
+6. Once your pull request has merged, your branch can be deleted.


### PR DESCRIPTION
# Description

The Karavi Observability repository will be the hub for documentation for other observability repositories.  Documentation content from other repositories is being moved over here in a strategic way to avoid duplication of documentation across the observability repositories.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|  #1         |

# Checklist:

- [x] I have performed a self-review of my own changes.
