### PR TITLE
Fixing exposed metrics data endpoint

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -103,6 +103,7 @@ In situations where an offline installation of Karavi Observability is required,
 | `karaviTopology.privateKeyFile`      | Optional public certificate's associated private key file that will be used to deploy the Topology service. Must use domain name 'karavi-topology'.            | ` `|
 | `otelCollector.certificateFile`      | Optional valid CA public certificate file that will be used to deploy the OpenTelemetry Collector. Must use domain name 'otel-collector'.            | ` `                                                   |
 | `otelCollector.privateKeyFile`      | Optional public certificate's associated private key file that will be used to deploy the OpenTelemetry Collector. Must use domain name 'otel-collector'.            | ` `|                                                   
+| `otelCollector.service.type`            | Kubernetes service type	    | `ClusterIP`                                                   |
 | `karaviMetricsPowerflex.powerflexEndpoint`      | PowerFlex Gateway URL            | ` `                                                   |
 | `karaviMetricsPowerflex.powerflexUser`                      | PowerFlex Gateway administrator username(in base64)                           | ` `                           |
 | `karaviMetricsPowerflex.powerflexPassword`                           | PowerFlex Gateway administrator password(in base64)                      | ` ` |
@@ -117,6 +118,7 @@ In situations where an offline installation of Karavi Observability is required,
 | `karaviMetricsPowerflex.volumeMetricsEnabled`                        | Enable PowerFlex Volume Metrics Collection                         | `true`                                       |
 | `karaviMetricsPowerflex.storageClassPoolMetricsEnabled`                        | Enable PowerFlex  Storage Class/Pool Metrics Collection                         | `true`                                       |
 | `karaviMetricsPowerflex.endpoint`                        | Endpoint for pod leader election                       | `karavi-metrics-powerflex`                                       |
+| `karaviMetricsPowerflex.service.type`            | Kubernetes service type	    | `ClusterIP`                                                   |
 
 Specify each parameter using the '--set key=value[,key=value]' and/or '--set-file key=value[,key=value] arguments to 'helm install'. For example:
 


### PR DESCRIPTION
# Description

Updated documentation to align with the helm chart changes that were made to not expose the metrics endpoint on the otel-collector.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #23      |

# Checklist:

- [x] I have performed a self-review of my own changes.
