### PR TITLE
Added install script for Karavi Observability

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -64,6 +64,18 @@ This project is deployed using Helm. The supported version of Helm is listed bel
 
 ## Installing the Chart
 
+There are several options for installing the Karavi Observability Helm chart including online and offline installer scripts and manual steps for installing the Helm chart.
+
+### Online Installation
+
+In situations where an online installation of Karavi Observability is required, please visit [Online Karavi Observability Helm Chart Installer](../installer/README.md#online-karavi-observability-helm-chart-installer) for more details.
+
+### Offline Installation
+
+In situations where an offline installation of Karavi Observability is required, please visit [Offline Karavi Observability Helm Chart Installer](../installer/README.md#offline-karavi-observability-helm-chart-installer) for more details.
+
+### Manual Installation
+
 Before installing the karavi-observability chart, you must first install the cert-manager CustomResourceDefinition resources with the command below.
 
 ```console
@@ -100,10 +112,6 @@ You may also want to uninstall the CRDs created for cert-manager.
 ```console
 $ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
 ```
-
-## Offline Installation
-
-In situations where an offline installation of Karavi Observability is required, please visit [Offline Installer](../installer/README.md) for more details.
 
 ## Configuration
 

--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -68,6 +68,8 @@ There are several options for installing the Karavi Observability Helm chart inc
 
 ### Online Installation
 
+> The online installation script is only supported with release 0.3.0-pre-release and v1.4.0 of the CSI Driver for Dell EMC PowerFlex
+
 In situations where an online installation of Karavi Observability is required, please visit [Online Karavi Observability Helm Chart Installer](../installer/README.md#online-karavi-observability-helm-chart-installer) for more details.
 
 ### Offline Installation
@@ -98,6 +100,24 @@ The command below deploys Karavi Observability on the Kubernetes cluster in the 
 ```console
 $ helm repo add dell https://dell.github.io/helm-charts
 $ helm install karavi-observability dell/karavi-observability -n karavi --create-namespace
+```
+
+## Updating Storage System Credentials
+
+> These instructions are only supported with release 0.3.0-pre-release and v1.4.0 of the CSI Driver for Dell EMC PowerFlex
+
+If the storage system credentials have changed and been updated in the relevant CSI Driver, Karavi Observability can be updated with new credentials as follows:
+
+### PowerFlex
+
+1. Delete the current `vxflexos-config` Secret from the Karavi Observability namespace.
+2. Copy the `vxflexos-config` Secret from the CSI Driver for Dell EMC PowerFlex namespace to the Karavi Observability namespace.
+
+*Example command to copy the secret from the vxflexos namespace to the karavi namespace:*
+
+```console
+$ kubectl delete secret vxflexos-config -n karavi
+$ kubectl get secret vxflexos-config -n vxflexos -o yaml | sed 's/namespace: vxflexos/namespace: karavi/' | kubectl create -f -
 ```
 
 ## Uninstalling the Chart

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,5 +1,7 @@
 *
 !.gitignore
 !offline-installer.sh
+!karavi-observability-install.sh
+!common.sh
 !README.md
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -10,7 +10,7 @@ You may obtain a copy of the License at
 
 # Karavi Observability Install Scripts
 
-This directory contains scripts to perform installation of Karavi Observability in the following environments:
+This `installer` directory contains scripts to perform installation of Karavi Observability in the following environments:
 
 - [Online Karavi Observability Helm Chart Installer](#online-karavi-observability-helm-chart-installer) - Installation environment has access to the internet to download Docker images, helm charts, and other dependencies.
 - [Offline Karavi Observability Helm Chart Installer](#offline-karavi-observability-helm-chart-installer) - Installation environment does not have access to the internet.
@@ -86,7 +86,7 @@ The following example will install Karavi Observability into the `karavi` namesp
 ```
 [user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh --namespace karavi --values myvalues.yaml
 ---------------------------------------------------------------------------------
-> Installing Karavi Observability in namespace karavi on 1.20
+> Installing Karavi Observability in namespace karavi on 1.19
 ---------------------------------------------------------------------------------
 |
 |- Karavi Observability is not installed                            Success

--- a/installer/README.md
+++ b/installer/README.md
@@ -8,6 +8,115 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 -->
 
+# Karavi Observability Install Scripts
+
+This directory contains scripts to perform installation of Karavi Observability in the following environments:
+
+- [Online Karavi Observability Helm Chart Installer](#online-karavi-observability-helm-chart-installer) - Installation environment has access to the internet to download Docker images, helm charts, and other dependencies.
+- [Offline Karavi Observability Helm Chart Installer](#offline-karavi-observability-helm-chart-installer) - Installation environment does not have access to the internet.
+
+# Online Karavi Observability Helm Chart Installer
+
+The following instructions can be followed to install Karavi Observability in an environment that has an internet connection and is capable of downloading the required helm chart and Docker images.
+
+## Dependencies
+
+A Linux based system, with internet access, will be used to execute the script to install Karavi Observability into a Kubernetes/Openshift enviornment that also has internet access.
+
+| Dependency            | Usage |
+| --------------------- | ----- |
+| `kubectl`   | `kubectl` will be used to verify the Kubernetes/OpenShift environment|
+| `helm`   | `helm` will be used to install the Karavi Observability helm chart|
+
+## Installation script
+The installation script is located at https://github.com/dell/karavi-observability/blob/main/installer/karavi-observability-installer.sh. The script performs the current steps during installation of Karavi Observability:
+
+- Verify that Karavi Observability is not yet installed
+- Verify the Kubernetes/Openshift versions are supported
+- Verify helm version is supported
+- Add the Dell helm chart repository
+- Refresh the helm chart repositories to download any recent changes
+- Create the Karavi Observability namespace (if not already created)
+- Copy the vxflexos-config Secret from the CSI PowerFlex namespace into the Karavi Observability namespace (if not already copied)
+- Install the CertManager CRDs (if not already installed)
+- Install the Karavi Observability helm chart
+- Wait for the Karavi Observability pods to become ready
+
+### Usage of the script is as follows:
+```
+[user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh --help
+
+Help for ./karavi-observability-install.sh
+
+Usage: ./karavi-observability-install.sh options...
+Options:
+  Required
+  --namespace[=]<namespace>                                   Namespace where Karavi Observability will be installed
+  Optional
+  --csi-powerflex-namespace[=]<csi powerflex namespace>       Namespace where CSI PowerFlex is installed, default is 'vxflexos'
+  --skip-verify                                               Skip verification of the environment
+  --values[=]<values.yaml>                                    Values file, which defines configuration values
+  --version[=]<helm chart version>                            Helm chart version to install, default value will be latest
+  --help                                                      Help
+```
+
+## Workflow
+
+To perform an online installation of Karavi Observability, the following steps should be performed:
+
+1. Clone the GitHub repository to be able to execute the scripts.
+2. Execute the installation script.
+
+### Clone the GitHub repository
+
+1. Clone the GitHub repository:
+```
+[user@system /home/user]# git clone https://github.com/dell/karavi-observability.git
+```
+
+### Execute the installation script
+
+1. Change to the installer directory:
+```
+[user@system /home/user]# cd karavi-observability/installer
+```
+
+2. Execute the installation script.
+The following example will install Karavi Observability into the `karavi` namespace.
+```
+[user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh --namespace karavi --values myvalues.yaml
+---------------------------------------------------------------------------------
+> Installing Karavi Observability in namespace karavi on 1.20
+---------------------------------------------------------------------------------
+|
+|- Karavi Observability is not installed                            Success
+|
+|- Verifying Kubernetes versions
+  |
+  |--> Verifying minimum Kubernetes version                         Success
+  |
+  |--> Verifying maximum Kubernetes version                         Success
+|
+|- Verifying helm version                                           Success
+|
+|- Configure helm chart repository
+  |
+  |--> Adding helm repository https://dell.github.io/helm-charts    Success
+  |
+  |--> Updating helm repositories                                   Success
+|
+|- Creating namespace karavi                                        Success
+|
+|- Copying vxflexos/config Secret from vxflexos to karavi           Success
+|
+|- Installing CertManager CRDs                                      Success
+|
+|- Installing Karavi Observability helm chart                       Success
+|
+|- Waiting for pods in namespace karavi to be ready                 Success
+
+```
+
 # Offline Karavi Observability Helm Chart Installer
 
 The following instructions can be followed when a Helm chart will be installed in an environment that does not have an internet connection and will be unable to download the Helm chart and related Docker images.
@@ -115,6 +224,14 @@ or
 ```
 [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl apply --validate=false -f cert-manager.crds.yaml
 ```
+
+> As of release 0.3.0-pre-release, the vxflexos-config Secret from the namespace where CSI Driver for Dell EMC PowerFlex is installed must be copied to the 
+> namespace where Karavi Observability is to be installed.
+>
+> Example command to copy the secret from the vxflexos namespace to the karavi namespace.
+>```
+>[user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret vxflexos-config -n vxflexos -o yaml | sed 's/namespace: vxflexos/namespace: karavi/' | kubectl create -f -
+>```
 
 3. Now that the required images have been made available and the Helm chart's configuration updated with references to the internal registry location, installation can proceed by following the instructions that are documented within the Helm chart's repository.
 

--- a/installer/common.sh
+++ b/installer/common.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+DARK_GRAY='\033[1;30m'
+NC='\033[0m' # No Color
+
+function decho() {
+  if [ -n "${DEBUGLOG}" ]; then
+    echo "$@" | tee -a "${DEBUGLOG}"
+  fi
+}
+
+function debuglog_only() {
+  if [ -n "${DEBUGLOG}" ]; then
+    echo "$@" >> "${DEBUGLOG}"
+  fi
+}
+
+function log() {
+  case $1 in
+  separator)
+    decho "---------------------------------------------------------------------------------"
+    ;;
+  error)
+    decho
+    log separator
+    printf "${RED}Error: $2\n"
+    printf "${RED}Installation cannot continue${NC}\n"
+    debuglog_only "Error: $2"
+    debuglog_only "Installation cannot continue"
+    exit 1
+    ;;
+  step)
+    printf "|\n|- %-65s" "$2"
+    debuglog_only "${2}"
+    ;;
+  small_step)
+    printf "%-61s" "$2"
+    debuglog_only "${2}"
+    ;;
+  section)
+    log separator
+    printf "> %s\n" "$2"
+    debuglog_only "${2}"
+    log separator
+    ;;
+  smart_step)
+    if [[ $3 == "small" ]]; then
+      log small_step "$2"
+    else
+      log step "$2"
+    fi
+    ;;
+  arrow)
+    printf "  %s\n  %s" "|" "|--> "
+    ;;
+  step_success)
+    printf "${GREEN}Success${NC}\n"
+    ;;
+  step_failure)
+    printf "${RED}Failed${NC}\n"
+    ;;
+  step_warning)
+    printf "${YELLOW}Warning${NC}\n"
+    ;;
+  info)
+    printf "${DARK_GRAY}%s${NC}\n" "$2"
+    ;;
+  passed)
+    printf "${GREEN}Success${NC}\n"
+    ;;
+  warnings)
+    printf "${YELLOW}Warnings:${NC}\n"
+    ;;
+  errors)
+    printf "${RED}Errors:${NC}\n"
+    ;;
+  *)
+    echo -n "Unknown"
+    ;;
+  esac
+}
+
+function check_error() {
+  if [[ $1 -ne 0 ]]; then
+    log step_failure
+  else
+    log step_success
+  fi
+}
+
+function run_command() {
+  local RC=0
+  if [ -n "${DEBUGLOG}" ]; then
+    local ME=$(basename "${0}")
+    echo "---------------" >> "${DEBUGLOG}"
+    echo "${ME}:${BASH_LINENO[0]} - Running command: $@" >> "${DEBUGLOG}"
+    debuglog_only "Results:"
+    eval "$@" | tee -a "${DEBUGLOG}"
+    RC=${PIPESTATUS[0]}
+    echo "---------------" >> "${DEBUGLOG}"
+  else
+    eval "$@"
+    RC=$?
+  fi
+  return $RC
+}

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -1,0 +1,400 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+source "$SCRIPTDIR"/common.sh
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+DARK_GRAY='\033[1;30m'
+NC='\033[0m' # No Color
+
+DEFAULT_CSI_POWERFLEX_NAMESPACE="vxflexos"
+CSI_POWERFLEX_NAMESPACE=""
+NAMESPACE=""
+VALUES=""
+
+VERIFY=1
+RELEASE="karavi-observability"
+
+export DEBUGLOG="${SCRIPTDIR}/install-debug.log"
+
+HELMREPO="https://dell.github.io/helm-charts"
+
+# adds the Dell helm repository and refreshes it
+function helm_repo_add() {
+  log step "Configure helm chart repository"
+  decho
+  log arrow
+  log smart_step "Adding helm repository ${HELMREPO}" "small"
+  run_command "helm repo add dell ${HELMREPO} > ${DEBUGLOG} 2>&1"
+  if [ $? -eq 1 ]; then
+    log error "Unable to add the helm repository. View logs at ${DEBUGLOG}"
+  fi
+  log step_success
+
+  log arrow
+  log smart_step "Updating helm repositories" "small"
+  run_command "helm repo update > ${DEBUGLOG} 2>&1"
+  if [ $? -eq 1 ]; then
+    log step_failure
+    log error "Unable to update the helm repository. View logs at ${DEBUGLOG}"
+  fi
+  log step_success
+}
+
+# creates the namespace for installing Karavi Observability
+function create_namespace() {
+  NUM=$(run_command "kubectl get namespaces | grep -e ^${NAMESPACE} | wc -l")
+  if [ "${NUM}" != "0" ]; then
+    log info "Namespace ${NAMESPACE} already exists"
+  else
+    log step "Creating namespace ${NAMESPACE}" "small"
+    run_command "kubectl create namespace ${NAMESPACE} > ${DEBUGLOG} 2>&1"
+      if [ $? -eq 1 ]; then
+        log step_failure
+        log error "Unable to create namespace ${NAMESPACE}. View logs at ${DEBUGLOG}"
+      else
+        log step_success
+      fi
+  fi  
+}
+
+# copies the vxflexos-config Secret from the CSI PowerFlex namespace into the namespace for Karavi Observability
+function copy_vxflexos_config_secret() {
+  NUM=$(run_command kubectl get secret --namespace "${NAMESPACE}" | grep -e ^vxflexos-config | wc -l)
+  if [ "${NUM}" != "0" ]; then
+    log info "Secret vxflexos-config already exists"
+  else
+    log step "Copying vxflexos/config Secret from ${CSI_POWERFLEX_NAMESPACE} to ${NAMESPACE}" "small"
+    run_command "kubectl get secret vxflexos-config -n ${CSI_POWERFLEX_NAMESPACE} -o yaml | sed 's/namespace: vxflexos/namespace: ${NAMESPACE}/' | kubectl create -f - > ${DEBUGLOG} 2>&1"
+    if [ $? -eq 1 ]; then
+      log step_failure
+      log error "Unable to copy secret from namespace ${CSI_POWERFLEX_NAMESPACE} to ${NAMESPACE}."
+    else
+      log step_success
+    fi
+  fi
+}
+
+# installs the CertManager CRDs
+function install_certmanager_crds() {
+  NUM=$(run_command kubectl get crd | grep -e ^certificates.cert-manager.io | wc -l)
+  if [ "${NUM}" != "0" ]; then
+    log info "Certmanager CRDs are already installed"
+  else
+    log step "Installing CertManager CRDs" "small"
+    run_command "kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml > ${DEBUGLOG} 2>&1"
+    if [ $? -eq 1 ]; then
+      log step_failure
+      log error "Unable to create cert-manager CRDs to ${NAMESPACE}."
+    else
+      log step_success
+    fi
+  fi
+}
+
+# checks if Karavi Observability is already installed in the namespace
+function check_for_karavi_observability() {
+  NUM=$(run_command helm list --namespace "${NAMESPACE}" | grep "${RELEASE}" | wc -l)
+  if [ "${NUM}" != "0" ]; then
+    log error "Karavi Observability is already installed"
+  else
+    log step "Karavi Observability is not installed" "small"
+    log step_success
+  fi
+}
+
+# install the Karavi Observability helm chart
+function install_karavi_observability() {
+  OPT_VALUES_ARG=""
+  if [ -n "$VALUES" ]; then
+      OPT_VALUES_ARG+="--values ${VALUES} "
+  fi
+  if [ -n "$VERSION" ]; then
+      OPT_VALUES_ARG+="--version ${VERSION} "
+  fi
+
+  log step "Installing Karavi Observability helm chart"
+  run_command "helm install \
+    ${OPT_VALUES_ARG} \
+    --namespace ${NAMESPACE} karavi-observability \
+    dell/karavi-observability > ${DEBUGLOG} 2>&1"
+    
+  if [ $? -ne 0 ]; then
+    cat "${DEBUGLOG}"
+    log error "Helm operation failed, output can be found in ${DEBUGLOG}. The failure should be examined, before proceeding."
+  fi
+  log step_success
+}
+
+# wait for the pods in the Karavi Observability namespace to be in a ready state
+function wait_on_pods() {
+  error=0
+  log step "Waiting for pods in namespace ${NAMESPACE} to be ready"
+  run_command "timeout 10m bash -c 'until date; kubectl wait --for=condition=ready --timeout=10m --all pods --namespace ${NAMESPACE}; do sleep 10; done' > ${DEBUGLOG} 2>&1"
+  if [ $? -ne 0 ]; then
+    error=1
+    log step_failure
+  else
+    log step_success
+  fi
+  if [ $error -ne 0 ]; then
+    log error "Timed out waiting for the operation to complete. This does not indicate a fatal error, pods may take a while to start. Progress can be checked by running \"kubectl get pods -n ${NAMESPACE}\""
+  fi
+  return 0
+}
+
+# verify the k8s, openshift, and helm environment prior to installation
+function verify_karavi_observability() {
+  if [ "${VERIFY}" == "0" ]; then
+    log info "Skipping verification of the environment"
+    return
+  fi
+  verify_k8s_versions "1.17" "1.20"
+  verify_openshift_versions "4.5" "4.6"
+  verify_helm_3
+}
+
+# verify minimum and maximum k8s versions
+function verify_k8s_versions() {
+  if [ "${OPENSHIFT}" == "true" ]; then
+    return
+  fi
+  log step "Verifying Kubernetes versions"
+  decho
+
+  local MIN=${1}
+  local MAX=${2}
+  local V="${kMajorVersion}.${kMinorVersion}"
+  # check minimum
+  log arrow
+  log smart_step "Verifying minimum Kubernetes version" "small"
+  error=0
+  if [[ ${V} < ${MIN} ]]; then
+    error=1
+    step_error "Kubernetes version, ${V}, is too old. Minimum required version is: ${MIN}"
+  fi
+  check_error error
+
+  # check maximum
+  log arrow
+  log smart_step "Verifying maximum Kubernetes version" "small"
+  error=0
+  if [[ ${V} > ${MAX} ]]; then
+    error=1
+    step_warning "Kubernetes version, ${V}, is newer than has been tested. Latest tested version is: ${MAX}"
+  fi
+  check_error error
+
+}
+
+# verify minimum and maximum openshift versions
+function verify_openshift_versions() {
+  if [ "${OPENSHIFT}" != "true" ]; then
+    return
+  fi
+  log step "Verifying OpenShift versions"
+  decho
+
+  local MIN=${1}
+  local MAX=${2}
+  local V=$(OpenShiftVersion)
+  # check minimum
+  log arrow
+  log smart_step "Verifying minimum OpenShift version" "small"
+  error=0
+  if [[ ${V} < ${MIN} ]]; then
+    error=1
+    step_error "OpenShift version, ${V}, is too old. Minimum required version is: ${MIN}"
+  fi
+  check_error error
+
+  # check maximum
+  log arrow
+  log smart_step "Verifying maximum OpenShift version" "small"
+  error=0
+  if [[ ${V} > ${MAX} ]]; then
+    error=1
+    step_warning "OpenShift version, ${V}, is newer than has been tested. Latest tested version is: ${MAX}"
+  fi
+  check_error error
+}
+
+# verify that helm is v3 or above
+function verify_helm_3() {
+  log step "Verifying helm version"
+  error=0
+  # Check helm installer version
+  helm --help >&/dev/null || {
+    step_error "helm is required for installation"
+    log step_failure
+    return
+  }
+
+  run_command helm version | grep "v3." --quiet
+  if [ $? -ne 0 ]; then
+    error=1
+    step_error "Driver installation is supported only using helm 3"
+  fi
+  check_error error
+}
+
+# validate_params will validate the parameters passed in
+function validate_params() {
+  # the namespace is required
+  if [ -z "${NAMESPACE}" ]; then
+    decho "No namespace specified"
+    usage
+    exit 1
+  fi
+  # if not overriding csi powerflex namespace, use the default
+  if [ -z "${CSI_POWERFLEX_NAMESPACE}" ]; then
+    CSI_POWERFLEX_NAMESPACE="${DEFAULT_CSI_POWERFLEX_NAMESPACE}"
+  fi
+  
+}
+
+# determines the version of OpenShift 
+# echos version, or empty string if not OpenShift
+function OpenShiftVersion() {
+  # check if this is OpenShift
+  local O=$(isOpenShift)
+  if [ "${O}" == "false" ]; then
+    # this is not openshift
+    echo ""
+  else
+    local V=$(run_command kubectl get clusterversions -o jsonpath="{.items[*].status.desired.version}")
+    local MAJOR=$(echo "${V}" | awk -F '.' '{print $1}')
+    local MINOR=$(echo "${V}" | awk -F '.' '{print $2}')
+    echo "${MAJOR}.${MINOR}"
+  fi
+}
+
+# returns true if the environment is openshift
+function isOpenShift() {
+  # check if the securitycontextconstraints.security.openshift.io crd exists
+  run_command kubectl get crd | grep securitycontextconstraints.security.openshift.io --quiet >/dev/null 2>&1
+  local O=$?
+  if [[ ${O} == 0 ]]; then
+    # this is openshift
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# make sure kubectl is available
+kubectl --help >&/dev/null || {
+  decho "kubectl required for verification... exiting"
+  exit 1
+}
+
+# Get the kubernetes major and minor version numbers.
+kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Major:"//' -e 's/[^0-9].*//g')
+kMinorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Minor:"//' -e 's/[^0-9].*//g')
+
+
+function usage() {
+  decho
+  decho "Help for $0"
+  decho
+  decho "Usage: $0 options..."
+  decho "Options:"
+  decho "  Required"
+  decho "  --namespace[=]<namespace>                                   Namespace where Karavi Observability will be installed"
+
+  decho "  Optional"
+  decho "  --csi-powerflex-namespace[=]<csi powerflex namespace>       Namespace where CSI PowerFlex is installed, default is 'vxflexos'"
+  decho "  --skip-verify                                               Skip verification of the environment"
+  decho "  --values[=]<values.yaml>                                    Values file, which defines configuration values"
+  decho "  --version[=]<helm chart version>                            Helm chart version to install, default value will be latest"
+  decho "  --help                                                      Help"
+  decho
+
+  exit 0
+}
+
+while getopts ":h-:" optchar; do
+  case "${optchar}" in
+  -)
+    case "${OPTARG}" in
+    skip-verify)
+      VERIFY=0
+      ;;
+    namespace)
+      NAMESPACE="${!OPTIND}"
+      OPTIND=$((OPTIND + 1))
+      ;;
+    namespace=*)
+      NAMESPACE=${OPTARG#*=}
+      ;;
+    csi-powerflex-namespace)
+      CSI_POWERFLEX_NAMESPACE="${!OPTIND}"
+      OPTIND=$((OPTIND + 1))
+      ;;
+    csi-powerflex-namespace=*)
+      CSI_POWERFLEX_NAMESPACE=${OPTARG#*=}
+      ;;
+    values)
+      VALUES="${!OPTIND}"
+      OPTIND=$((OPTIND + 1))
+      ;;
+    values=*)
+      VALUES=${OPTARG#*=}
+      ;;
+    version)
+      VERSION="${!OPTIND}"
+      OPTIND=$((OPTIND + 1))
+      ;;
+    version=*)
+      VERSION=${OPTARG#*=}
+      ;;
+    help)
+      usage
+      exit 0
+      ;;
+    *)
+      decho "Unknown option --${OPTARG}"
+      decho "For help, run $PROG -h"
+      exit 1
+      ;;
+    esac
+    ;;
+  *)
+    decho "Unknown option -${OPTARG}"
+    decho "For help, run $PROG -h"
+    exit 1
+    ;;
+  esac
+done
+
+validate_params
+
+OPENSHIFT=$(isOpenShift)
+
+log section "Installing Karavi Observability in namespace ${NAMESPACE} on ${kMajorVersion}.${kMinorVersion}"
+
+check_for_karavi_observability 
+
+verify_karavi_observability
+
+helm_repo_add
+
+create_namespace 
+
+copy_vxflexos_config_secret
+
+install_certmanager_crds
+
+install_karavi_observability
+
+wait_on_pods

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -165,7 +165,7 @@ function verify_karavi_observability() {
     log info "Skipping verification of the environment"
     return
   fi
-  verify_k8s_versions "1.17" "1.20"
+  verify_k8s_versions "1.17" "1.19"
   verify_openshift_versions "4.5" "4.6"
   verify_helm_3
 }


### PR DESCRIPTION
# Description
This PR adds a new install script that can be used to install Karavi Observability into a Kubernetes/Openshift environment. The script has the following steps:

```
- Verify that Karavi Observability is not yet installed
- Verify the Kubernetes/Openshift versions are supported
- Verify helm version is supported
- Add the Dell helm chart repository
- Refresh the helm chart repositories to download any recent changes
- Create the Karavi Observability namespace (if not already created)
- Copy the vxflexos-config Secret from the CSI PowerFlex namespace into the Karavi Observability namespace (if not already copied)
- Install the CertManager CRDs (if not already installed)
- Install the Karavi Observability helm chart
- Wait for the Karavi Observability pods to become ready
```

Example output when using the script to install Karavi Observability:

```
./karavi-observability-install.sh --namespace karavi --values myvalues.yaml
---------------------------------------------------------------------------------
> Installing Karavi Observability in namespace karavi on 1.19
---------------------------------------------------------------------------------
|
|- Karavi Observability is not installed                            Success
|
|- Verifying Kubernetes versions
  |
  |--> Verifying minimum Kubernetes version                         Success
  |
  |--> Verifying maximum Kubernetes version                         Success
|
|- Verifying helm version                                           Success
|
|- Configure helm chart repository
  |
  |--> Adding helm repository https://dell.github.io/helm-charts    Success
  |
  |--> Updating helm repositories                                   Success
|
|- Creating namespace karavi                                        Success
|
|- Copying vxflexos/config Secret from vxflexos to karavi           Success
|
|- Installing CertManager CRDs                                      Success
|
|- Installing Karavi Observability helm chart                       Success
|
|- Waiting for pods in namespace karavi to be ready                 Success

NAME: karavi-observability
LAST DEPLOYED: Wed Mar  3 08:12:11 2021
NAMESPACE: karavi
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Karavi Topology
  The Karavi Topology deployment has been successfully installed.

Execute the following commands in your shell to print the URL that can be used to access the Karavi Topology service:
  export NODE_PORT=$(kubectl get --namespace karavi -o jsonpath="{.spec.ports[0].nodePort}" services karavi-topology)
  export NODE_IP=$(kubectl get nodes --namespace karavi -o jsonpath="{.items[0].status.addresses[0].address}")
  echo https://$NODE_IP:$NODE_PORT


Karavi Metrics for PowerFlex

  The Karavi Metrics for PowerFlex deployment has been successfully installed.

  PowerFlex Endpoint: https://<ip-here>
  Provisioner Names: csi-vxflexos.dellemc.com
  Prometheus Scrape Target:
    From inside the Kubernetes cluster: otel-collector:8443
```


# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|    #33       |

# Checklist:

- [x] I have performed a self-review of my own changes.
