### PR TITLE
Updated installer script to enable authorization

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -114,6 +114,34 @@ If the storage system credentials have changed and been updated in the relevant 
 
 ### PowerFlex
 
+#### If using Karavi Observability with Karavi Authorization
+
+##### Update Karavi Authorization Token
+1. Delete the current `proxy-authz-tokens` Secret from the Karavi Observability namespace.
+2. Copy the `proxy-authz-tokens` Secret from the CSI Driver for Dell EMC PowerFlex namespace to the Karavi Observability namespace.
+
+*Example command to copy the secret from the vxflexos namespace to the karavi namespace:*
+
+```console
+$ kubectl delete secret proxy-authz-tokens -n karavi
+$ kubectl get secret proxy-authz-tokens -n vxflexos -o yaml | sed 's/namespace: vxflexos/namespace: karavi/' | kubectl create -f -
+```
+
+##### Update Storage Systems
+If the list of storage systems managed by the CSI Driver for Dell EMC PowerFlex has changed, the following steps can be performed to update Karavi Observability to reference the updated systems:
+
+1. Delete the current `karavi-authorization-config` Secret from the Karavi Observability namespace.
+2. Copy the `karavi-authorization-config` Secret from the CSI Driver for Dell EMC PowerFlex namespace to the Karavi Observability namespace.
+
+*Example command to copy the secret from the vxflexos namespace to the karavi namespace:*
+
+```console
+$ kubectl delete secret karavi-authorization-config -n karavi
+$ kubectl get secret karavi-authorization-config -n vxflexos -o yaml | sed 's/namespace: vxflexos/namespace: karavi/' | kubectl create -f -
+```
+
+#### If not using Karavi Observability with Karavi Authorization
+
 1. Delete the current `vxflexos-config` Secret from the Karavi Observability namespace.
 2. Copy the `vxflexos-config` Secret from the CSI Driver for Dell EMC PowerFlex namespace to the Karavi Observability namespace.
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -65,6 +65,7 @@ Options:
   --auth-image-addr                                           Docker registry location of the Karavi Authorization sidecar proxy image
   --auth-proxy-host                                           Host address of the Karavi Authorization proxy server
   --csi-powerflex-namespace[=]<csi powerflex namespace>       Namespace where CSI PowerFlex is installed, default is 'vxflexos'
+  --set-file                                                  Set values from files used during helm installation (can be specified multiple times)
   --skip-verify                                               Skip verification of the environment
   --values[=]<values.yaml>                                    Values file, which defines configuration values
   --verbose                                                   Display verbose logging

--- a/installer/README.md
+++ b/installer/README.md
@@ -42,20 +42,32 @@ The installation script is located at https://github.com/dell/karavi-observabili
 - Install the Karavi Observability helm chart
 - Wait for the Karavi Observability pods to become ready
 
+If Karavi Authorization is enabled for the CSI drivers installed in the same Kubernetes cluster, the installation script will perform the current steps to enable Karavi Observability to use the same Karavi Authorization instance:
+- Verify the `karavictl` binary is available.
+- Verify the appropriate Secret exists in the CSI driver namespace.
+- Query the CSI driver environment to get references to the Karavi Authorization sidecar-proxy Docker image and URL of the proxy server.
+- Updates the Karavi Observability deployment to use the existing Karavi Authorization instance.
+
 ### Usage of the script is as follows:
 ```
 [user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh --help
 
 Help for ./karavi-observability-install.sh
 
-Usage: ./karavi-observability-install.sh options...
+Usage: ./karavi-observability-install.sh mode options...
+Mode:
+  install                                                     Installs Karavi Observability and enables Karavi Authorization if already installed
+  enable-authorization                                        Updates existing installation of Karavi Observability with Karavi Authorization
 Options:
   Required
   --namespace[=]<namespace>                                   Namespace where Karavi Observability will be installed
   Optional
+  --auth-image-addr                                           Docker registry location of the Karavi Authorization sidecar proxy image
+  --auth-proxy-host                                           Host address of the Karavi Authorization proxy server
   --csi-powerflex-namespace[=]<csi powerflex namespace>       Namespace where CSI PowerFlex is installed, default is 'vxflexos'
   --skip-verify                                               Skip verification of the environment
   --values[=]<values.yaml>                                    Values file, which defines configuration values
+  --verbose                                                   Display verbose logging
   --version[=]<helm chart version>                            Helm chart version to install, default value will be latest
   --help                                                      Help
 ```
@@ -84,12 +96,14 @@ To perform an online installation of Karavi Observability, the following steps s
 2. Execute the installation script.
 The following example will install Karavi Observability into the `karavi` namespace.
 ```
-[user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh --namespace karavi --values myvalues.yaml
+[user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh install --namespace karavi --values myvalues.yaml
 ---------------------------------------------------------------------------------
 > Installing Karavi Observability in namespace karavi on 1.19
 ---------------------------------------------------------------------------------
 |
 |- Karavi Observability is not installed                            Success
+|
+|- Karavi Authorization will be enabled during installation
 |
 |- Verifying Kubernetes versions
   |
@@ -107,14 +121,19 @@ The following example will install Karavi Observability into the `karavi` namesp
 |
 |- Creating namespace karavi                                        Success
 |
-|- Copying vxflexos/config Secret from vxflexos to karavi           Success
+|- Copying Secret from vxflexos to karavi                           Success
 |
 |- Installing CertManager CRDs                                      Success
 |
 |- Installing Karavi Observability helm chart                       Success
 |
 |- Waiting for pods in namespace karavi to be ready                 Success
-
+|
+|- Copying Secret from vxflexos to karavi                           Success
+|
+|- Enabling Karavi Authorization for Karavi Observability           Success
+|
+|- Waiting for pods in namespace karavi to be ready                 Success
 ```
 
 # Offline Karavi Observability Helm Chart Installer
@@ -245,4 +264,18 @@ STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 
+```
+
+> As of release 0.3.0-pre-release, the following optional step can be performed to enable Karavi Observability to use an existing Karavi Authorization.
+
+4. (Optional) The following steps can be performed to enable Karavi Observability to use an existing instance of Karavi Authorization for accessing the REST API for the given storage systems.
+
+Copy the proxy Secret into the Karavi Observability namespace:
+```
+[user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret proxy-authz-tokens -n vxflexos -o yaml | sed 's/namespace: vxflexos/namespace: karavi/' | kubectl create -f -
+```
+
+Use `karavictl` to update the Karavi Observability deployment to use Karavi Authorization. Required parameters are the location of the sidecar-proxy Docker image and URL of the Karavi Authorization proxy:
+```
+[user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secrets,deployments -n karavi -o yaml | karavictl inject --image-addr <sidecar-proxy-image-location> --proxy-host <proxy-host> | kubectl apply -f -
 ```

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -35,6 +35,8 @@ ENABLE_AUTHORIZATION_DURING_INSTALL=0
 KARAVICTL_INSTALLED=0
 KARAVI_AUTHORIZATION_PROXY_AUTHZ_TOKENS_SECRET_EXISTS=0
 
+HELM_SET_FILES=()
+
 export DEBUGLOG="${SCRIPTDIR}/install-debug.log"
 export HELMLOG="${SCRIPTDIR}/helm-install.log"
 
@@ -157,6 +159,9 @@ function install_karavi_observability() {
   if [ -n "$VERSION" ]; then
       OPT_VALUES_ARG+="--version ${VERSION} "
   fi
+  for i in ${!HELM_SET_FILES[@]}; do
+    OPT_VALUES_ARG+="--set-file ${HELM_SET_FILES[$i]} "
+  done
 
   log step "Installing Karavi Observability helm chart"
   run_command "helm install \
@@ -359,6 +364,7 @@ function usage() {
   decho "  --auth-image-addr                                           Docker registry location of the Karavi Authorization sidecar proxy image"
   decho "  --auth-proxy-host                                           Host address of the Karavi Authorization proxy server"
   decho "  --csi-powerflex-namespace[=]<csi powerflex namespace>       Namespace where CSI PowerFlex is installed, default is 'vxflexos'"
+  decho "  --set-file                                                  Set values from files used during helm installation (can be specified multiple times)"
   decho "  --skip-verify                                               Skip verification of the environment"
   decho "  --values[=]<values.yaml>                                    Values file, which defines configuration values"
   decho "  --verbose                                                   Display verbose logging"
@@ -415,6 +421,13 @@ while getopts ":h-:" optchar; do
       ;;
     csi-powerflex-namespace=*)
       CSI_POWERFLEX_NAMESPACE=${OPTARG#*=}
+      ;;
+    set-file)
+      HELM_SET_FILES+=(${!OPTIND})
+      OPTIND=$((OPTIND + 1))
+      ;;
+    set-file=*)
+      HELM_SET_FILES+=(${OPTARG#*=})
       ;;
     values)
       VALUES="${!OPTIND}"


### PR DESCRIPTION
# Description
This PR updates the Karavi Observability installer script to enable Karavi Authorization if the following conditions are true:
- The proxy-authz-tokens Secret exists in the vxflexos namespace
- The `karavictl` binary is available on the PATH

During install, the script will copy over the proxy-authz-tokens Secret and then execute `karavictl` to inject Karavi Authorization into the Karavi Observability deployment. (https://github.com/dell/karavi-authorization/pull/40)

The script now supports 2 modes:
- install: When Karavi Observability is not yet deployed
- enable-authorization: When Karavi Observability is already deployed and the customer wants to enable it to use Karavi Authorization

The script also supports the `--set-file` option that will pass files into the helm installation. This can be used for passing certificate and private key files if not using the default self-signed certificates.

# Testing
- Ran the script to deploy Karavi Observability into an environment where Karavi Authorization was already installed. The script made appropriate changes to allow Karavi Observability to use the existing Karavi Authorization environment.
- Ran the script to deploy Karavi Observability in an environment where Karavi Authorization was not installed. Then installed Karavi Authorization and ran the script using the `enable-authorization`.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|   #30        |

# Checklist:

- [x] I have performed a self-review of my own changes.
