### PR TITLE
Set inject flags depending if a certificate file was specified in a configuration file

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -27,6 +27,7 @@ A Linux based system, with internet access, will be used to execute the script t
 | --------------------- | ----- |
 | `kubectl`   | `kubectl` will be used to verify the Kubernetes/OpenShift environment|
 | `helm`   | `helm` will be used to install the Karavi Observability helm chart|
+| `jq`     | `jq` will be used to parse the Karavi Authorization configuration file during installation|
 
 ## Installation script
 The installation script is located at https://github.com/dell/karavi-observability/blob/main/installer/karavi-observability-installer.sh. The script performs the current steps during installation of Karavi Observability:
@@ -273,7 +274,7 @@ Copy the proxy Secret into the Karavi Observability namespace:
 [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret proxy-authz-tokens -n vxflexos -o yaml | sed 's/namespace: vxflexos/namespace: karavi/' | kubectl create -f -
 ```
 
-Use `karavictl` to update the Karavi Observability deployment to use Karavi Authorization. Required parameters are the location of the sidecar-proxy Docker image and URL of the Karavi Authorization proxy:
+Use `karavictl` to update the Karavi Observability deployment to use Karavi Authorization. Required parameters are the location of the sidecar-proxy Docker image and URL of the Karavi Authorization proxy. If Karavi Authorization was installed using certificates, the flags `--insecure=false` and `--root-certificate <location-of-root-certificate>` must be also be provided. If certificates were not provided during installation, the flag `--insecure=true` must be provided.
 ```
-[user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secrets,deployments -n karavi -o yaml | karavictl inject --image-addr <sidecar-proxy-image-location> --proxy-host <proxy-host> | kubectl apply -f -
+[user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secrets,deployments -n karavi -o yaml | karavictl inject --insecure=false --root-certificate <location-of-root-certificate> --image-addr <sidecar-proxy-image-location> --proxy-host <proxy-host> | kubectl apply -f -
 ```


### PR DESCRIPTION
# Description

If Karavi Authorization is installed, check the location of the configuration files to determine if a root CA was provided during installation of the Karavi Authorization proxy server.

If a certificate was provided, use flags `--insecure=false --root-certificate <location-of-certificate>` so that the communication between the sidecar-proxy and proxy-server is trusted. 

If a certificate was not provided or the configuration files are not found, use flag `--insecure=true` for communication between the sidecar-proxy and proxy-server.

# Testing
E2E output after deploying with flag `--insecure=true`:
```
# go test -count=1 -p 1 -race -timeout 1h ./karavi-topology/observ-test/
ok      karavi-testing/karavi-topology/observ-test      58.299s
# go test -count=1 -p 1 -race -timeout 1h ./karavi-metrics-powerflex/observ-test/
ok      karavi-testing/karavi-metrics-powerflex/observ-test     440.280s
```

E2E output after deploying with flags `--insecure=false --root-certificate <location-of-certificate>`:
```
# go test -count=1 -p 1 -race -timeout 1h ./karavi-topology/observ-test/
ok      karavi-testing/karavi-topology/observ-test      69.007s
# go test -count=1 -p 1 -race -timeout 1h ./karavi-metrics-powerflex/observ-test/
ok      karavi-testing/karavi-metrics-powerflex/observ-test     482.580s
```

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|    #40       |

# Checklist:

- [x] I have performed a self-review of my own changes.
