### PR TITLE
Updated installer and documentation for powerstore metrics

### DIFF
--- a/docs/GETTING_STARTED_GUIDE.md
+++ b/docs/GETTING_STARTED_GUIDE.md
@@ -178,7 +178,8 @@ $ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v
 
 | Parameter                                 | Description                                   | Default                                                 |
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| `karaviTopology.image`                   | Location of the karavi-topology Docker image                                                                                                        | `dellemc/karavi-topology:0.1.0-pre-release`|
+| `karaviTopology.image`                   | Location of the karavi-topology Docker image                                                                                                        | `dellemc/csm-topology:v0.3.0`|
+| `karaviTopology.enabled`       | Enable Karavi Topology service    | `true`                                                   |
 | `karaviTopology.provisionerNames`       | Provisioner Names used to filter the Persistent Volumes created on the Kubernetes cluster (must be a comma-separated list)    | ` csi-vxflexos.dellemc.com`                                                   |
 | `karaviTopology.service.type`            | Kubernetes service type	    | `ClusterIP`                                                   |
 | `karaviTopology.certificateFile`      | Optional valid CA public certificate file that will be used to deploy the Topology service. Must use domain name 'karavi-topology'.            | ` `                                                   |
@@ -188,7 +189,8 @@ $ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v
 | `otelCollector.certificateFile`      | Optional valid CA public certificate file that will be used to deploy the OpenTelemetry Collector. Must use domain name 'otel-collector'.            | ` `                                                   |
 | `otelCollector.privateKeyFile`      | Optional public certificate's associated private key file that will be used to deploy the OpenTelemetry Collector. Must use domain name 'otel-collector'.            | ` `|                                                   
 | `otelCollector.service.type`            | Kubernetes service type	    | `ClusterIP`                                                   |
-| `karaviMetricsPowerflex.image`                          |  Karavi Metrics for PowerFlex Service image                      | `dellemc/karavi-metrics-powerflex:0.1.0-pre-release`|
+| `karaviMetricsPowerflex.image`                          |  Karavi Metrics for PowerFlex Service image                      | `dellemc/csm-metrics-powerflex:v0.3.0`|
+| `karaviMetricsPowerflex.enabled`                          |  Enable Karavi Metrics for PowerFlex service                      | `true`|
 | `karaviMetricsPowerflex.collectorAddr`                         | Metrics Collector accessible from the Kubernetes cluster                    | `otel-collector:55680`  |
 | `karaviMetricsPowerflex.provisionerNames`                       | Provisioner Names used to filter for determining PowerFlex SDC nodes( Must be a Comma-separated list)          | ` csi-vxflexos.dellemc.com`                                                   |
 | `karaviMetricsPowerflex.sdcPollFrequencySeconds`                        | The polling frequency (in seconds) to gather SDC metrics                         | `10`                                       |
@@ -202,6 +204,17 @@ $ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v
 | `karaviMetricsPowerflex.service.type`            | Kubernetes service type	    | `ClusterIP`                                                   |
 | `karaviMetricsPowerflex.logLevel`      | *As of Release 0.4.0:* Output logs that are at or above the given log level severity (Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC)           | `INFO`|
 | `karaviMetricsPowerflex.logFormat`      | *As of Release 0.4.0:* Output logs in the specified format (Valid values: text, json)            | `text`|
+| `karaviMetricsPowerstore.image`                          |  *As of Release 0.4.0:* Karavi Metrics for PowerStore Service image                      | `dellemc/csm-metrics-powerstore:v0.1.0`|
+| `karaviMetricsPowerstore.enabled`                          |  *As of Release 0.4.0:* Enable Karavi Metrics for PowerStore service                      | `true`|
+| `karaviMetricsPowerstore.collectorAddr`                         | *As of Release 0.4.0:* Metrics Collector accessible from the Kubernetes cluster                    | `otel-collector:55680`  |
+| `karaviMetricsPowerstore.provisionerNames`                       | *As of Release 0.4.0:* Provisioner Names used to filter for determining PowerStore volumes (must be a Comma-separated list)          | ` csi-powerstore.dellemc.com`                                                   |
+| `karaviMetricsPowerstore.volumePollFrequencySeconds`                        | *As of Release 0.4.0:* The polling frequency (in seconds) to gather volume metrics | `10`                         |
+| `karaviMetricsPowerstore.concurrentPowerflexQueries`                        | *As of Release 0.4.0:* The number of simultaneous metrics queries to make to PowerStore (must be less than 10; otherwise, several request errors from PowerStore will ensue.)                       |  `10`                                       |
+| `karaviMetricsPowerstore.volumeMetricsEnabled`                        | *As of Release 0.4.0:* Enable PowerStore Volume Metrics Collection                         | `true`                                       |
+| `karaviMetricsPowerstore.endpoint`                        | *As of Release 0.4.0:* Endpoint for pod leader election                       | `karavi-metrics-powerstore`                                       |
+| `karaviMetricsPowerstore.service.type`            | *As of Release 0.4.0:* Kubernetes service type	    | `ClusterIP`                                                   |
+| `karaviMetricsPowerstore.logLevel`      | *As of Release 0.4.0:* Output logs that are at or above the given log level severity (Valid values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC)           | `INFO`|
+| `karaviMetricsPowerstore.logFormat`      | *As of Release 0.4.0:* Output logs in the specified format (Valid values: text, json)            | `text`|
 
 Specify each parameter using the '--set key=value[,key=value]' and/or '--set-file key=value[,key=value] arguments to 'helm install'. For example:
 
@@ -223,6 +236,9 @@ $ helm install karavi-observability dell/karavi-observability -n karavi --create
 
 **PowerFlex System Details**
 - Karavi Observability will use the same vxflexos-config Secret that is used by release 1.4 of the CSI Driver for Dell EMC PowerFlex. If a 'default' storage system is specified, metrics will only be gathered for that system. If no 'default' storage system is specified, the first system in the configuration will be used.
+
+**PowerStore System Details**
+- Karavi Observability will use the same powerstore-config Secret that is used by release 1.3 of the CSI Driver for Dell EMC PowerStore. Metrics will be gathered for all storage systems specified in the Secret.
 
 **Configuration Settings**
 - Some parameters can be configured during runtime without restarting the Karavi Observability services. These parameters will be stored in ConfigMaps that can be updated on the Kubernetes cluster. This will automatically change the settings on the services.
@@ -247,6 +263,23 @@ To update the karavi-metrics-powerflex settings during runtime, run the below co
 ```console
 kubectl edit configmap karavi-metrics-powerflex-configmap -n karavi
 ```
+
+>As of Release 0.4.0:
+>Karavi-metrics-powerstore parameters that can be updated:
+>
+>* COLLECTOR_ADDR
+>* PROVISIONER_NAMES
+>* POWERSTORE_VOLUME_IO_POLL_FREQUENCY
+>* POWERSTORE_VOLUME_METRICS_ENABLED
+>* POWERSTORE_MAX_CONCURRENT_QUERIES
+>* LOG_LEVEL
+>* LOG_FORMAT
+>
+> To update the karavi-metrics-powerstore settings during runtime, run the below command on the Kubernetes cluster and save the updated configmap data.
+>
+>```console
+>kubectl edit configmap karavi-metrics-powerstore-configmap -n karavi
+>```
 
 Karavi-topology parameters that can be updated:
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -253,7 +253,14 @@ Example command to copy the Secret from the vxflexos namespace to the karavi nam
 [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret vxflexos-config -n vxflexos -o yaml | sed 's/namespace: vxflexos/namespace: karavi/' | kubectl create -f -
 ```
 
-4. Now that the required images have been made available and the Helm chart's configuration updated with references to the internal registry location, installation can proceed by following the instructions that are documented within the Helm chart's repository.
+4. The powerstore-config Secret from the namespace where CSI Driver for Dell EMC PowerStore is installed must be copied to the namespace where Karavi Observability is to be installed.
+
+Example command to copy the Secret from the csi-powerstore namespace to the karavi namespace.
+```
+[user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret pwoerstore-config -n csi-powerstore -o yaml | sed 's/namespace: csi-powerstore/namespace: karavi/' | kubectl create -f -
+```
+
+5. Now that the required images have been made available and the Helm chart's configuration updated with references to the internal registry location, installation can proceed by following the instructions that are documented within the Helm chart's repository.
 
 ```
 [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# helm install -n install-namespace app-name karavi-observability

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -427,7 +427,7 @@ function usage() {
   decho "  --auth-image-addr                                           Docker registry location of the Karavi Authorization sidecar proxy image"
   decho "  --auth-proxy-host                                           Host address of the Karavi Authorization proxy server"
   decho "  --csi-powerflex-namespace[=]<csi powerflex namespace>       Namespace where CSI PowerFlex is installed, default is 'vxflexos'"
-  decho "  --csi-powerstore-namespace[=]<csi powerflex namespace>      Namespace where CSI PowerStore is installed, default is 'csi-powerstore'"
+  decho "  --csi-powerstore-namespace[=]<csi powerstore namespace>     Namespace where CSI PowerStore is installed, default is 'csi-powerstore'"
   decho "  --set-file                                                  Set values from files used during helm installation (can be specified multiple times)"
   decho "  --skip-verify                                               Skip verification of the environment"
   decho "  --values[=]<values.yaml>                                    Values file, which defines configuration values"


### PR DESCRIPTION
# Description
Updated the installer and documentation to support the PowerStore metrics service. The installer will now detect which CSI Drivers are installed and only enable those metrics services.

Updated helm chart PR: https://github.com/dell/helm-charts/pull/87

# Testing
Successfully tested the installer to deploy the PowerStore metrics service.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|   https://github.com/dell/karavi-observability/issues/48       |

# Checklist:

- [x] I have performed a self-review of my own changes.
