### PR TITLE
Adds upgrade to online installer script

### DIFF
--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -194,18 +194,15 @@ function install_certmanager_crds() {
   fi
 }
 
-# remove CertManager CRDs before upgrade
-function remove_certmanager_crds() {
+# upgrades CertManager CRDs
+function upgrade_certmanager_crds() {
   NUM=$(run_command kubectl get crd | grep -e '^certificates.cert-manager.io\s' | wc -l)
   if [ "${NUM}" != "0" ]; then
-    log step "Certmanager CRDs are installed"
-    decho
-    log arrow
-    log smart_step "Removing old CertManager CRDs before upgrade" "small"
-    run_command "kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml > ${DEBUGLOG} 2>&1"
+    log step "Upgrading CertManager CRDs" "small"
+    run_command "kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml > ${DEBUGLOG} 2>&1"
     if [ $? -eq 1 ]; then
       log step_failure
-      log error "Unable to remove cert-manager CRDs from ${NAMESPACE}."
+      log error "Unable to upgrade cert-manager CRDs."
     else
       log step_success
     fi
@@ -738,8 +735,7 @@ case $MODE in
       log error "Karavi Observability is not installed" "small"
     fi
     verify_karavi_observability
-    remove_certmanager_crds
-    install_certmanager_crds
+    upgrade_certmanager_crds
     upgrade_karavi_observability
     wait_on_pods
     display_helm_log

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -467,7 +467,7 @@ function usage() {
   decho "Mode:"
   decho "  install                                                     Installs Karavi Observability and enables Karavi Authorization if already installed"
   decho "  enable-authorization                                        Updates existing installation of Karavi Observability with Karavi Authorization"
-  decho "  upgrade                                                     Upgrades existing installation of Karavi Observability to a specified release version"
+  decho "  upgrade                                                     Upgrades existing installation of Karavi Observability to the latest release"
   decho "Options:"
   decho "  Required"
   decho "  --namespace[=]<namespace>                                   Namespace where Karavi Observability will be installed"
@@ -728,7 +728,7 @@ case $MODE in
     ;;
   "upgrade")
     validate_params
-    log section "Upgrading Karavi Observability in namespace ${NAMESPACE}"
+    log section "Upgrading Karavi Observability in namespace ${NAMESPACE} on ${kMajorVersion}.${kMinorVersion}"
     is_karavi_observability_installed
     if [[ $? == "0" ]]; then
       log step "Karavi Observability is installed. Upgrade can continue" "small"

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -47,6 +47,8 @@ export HELMLOG="${SCRIPTDIR}/helm-install.log"
 
 HELMREPO="https://dell.github.io/helm-charts"
 
+CRD="kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml"
+
 # adds the Dell helm repository and refreshes it
 function helm_repo_add() {
   log step "Configure helm chart repository"
@@ -184,7 +186,7 @@ function install_certmanager_crds() {
     log info "Certmanager CRDs are already installed"
   else
     log step "Installing CertManager CRDs" "small"
-    run_command "kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml > ${DEBUGLOG} 2>&1"
+    run_command "${CRD} > ${DEBUGLOG} 2>&1"
     if [ $? -eq 1 ]; then
       log step_failure
       log error "Unable to create cert-manager CRDs to ${NAMESPACE}."
@@ -199,7 +201,7 @@ function upgrade_certmanager_crds() {
   NUM=$(run_command kubectl get crd | grep -e '^certificates.cert-manager.io\s' | wc -l)
   if [ "${NUM}" != "0" ]; then
     log step "Upgrading CertManager CRDs" "small"
-    run_command "kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml > ${DEBUGLOG} 2>&1"
+    run_command "${CRD} > ${DEBUGLOG} 2>&1"
     if [ $? -eq 1 ]; then
       log step_failure
       log error "Unable to upgrade cert-manager CRDs."

--- a/installer/offline-installer.sh
+++ b/installer/offline-installer.sh
@@ -72,7 +72,7 @@ create_bundle() {
     run_command "helm dependency update ${DISTDIR}/${HELMBACKUPDIR}/${CHART}"
 
     # add cert-manager crds file to bundle
-    run_command "wget -O ${DISTDIR}/${HELMBACKUPDIR}/cert-manager.crds.yaml https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml"
+    run_command "curl -o ${DISTDIR}/${HELMBACKUPDIR}/cert-manager.crds.yaml -L https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml"
 
     # copy this script into the distribution directory
     cp $0 ${DISTDIR}

--- a/installer/offline-installer.sh
+++ b/installer/offline-installer.sh
@@ -72,7 +72,7 @@ create_bundle() {
     run_command "helm dependency update ${DISTDIR}/${HELMBACKUPDIR}/${CHART}"
 
     # add cert-manager crds file to bundle
-    run_command "curl -o ${DISTDIR}/${HELMBACKUPDIR}/cert-manager.crds.yaml https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml"
+    run_command "curl -o ${DISTDIR}/${HELMBACKUPDIR}/cert-manager.crds.yaml https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml"
 
     # copy this script into the distribution directory
     cp $0 ${DISTDIR}

--- a/installer/offline-installer.sh
+++ b/installer/offline-installer.sh
@@ -72,7 +72,7 @@ create_bundle() {
     run_command "helm dependency update ${DISTDIR}/${HELMBACKUPDIR}/${CHART}"
 
     # add cert-manager crds file to bundle
-    run_command "curl -o ${DISTDIR}/${HELMBACKUPDIR}/cert-manager.crds.yaml https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml"
+    run_command "wget -O ${DISTDIR}/${HELMBACKUPDIR}/cert-manager.crds.yaml https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml"
 
     # copy this script into the distribution directory
     cp $0 ${DISTDIR}


### PR DESCRIPTION
# Description
This PR adds upgrade support to the online installer script. The cert-manager version used in the offline installer script has also been updated to v1.5.3.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/151|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have made corresponding changes to the documentation
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Upgrade performed from v1.0.0 to v1.0.1 using the online installer script:
./karavi-observability-install.sh upgrade --values myvalues.yaml --version 1.0.1 --namespace karavi
---------------------------------------------------------------------------------
> Upgrading Karavi Observability in namespace karavi on 1.21
---------------------------------------------------------------------------------
|
|- Karavi Observability is installed. Upgrade can continue          Success
|
|- Verifying Kubernetes versions
  |
  |--> Verifying minimum Kubernetes version                         Success
  |
  |--> Verifying maximum Kubernetes version                         Success
|
|- Verifying helm version                                           Success
|
|- Upgrading CertManager CRDs                                       Success
|
|- Updating helm repositories                                       Success
|
|- Upgrading Karavi Observability helm chart                        Success
|
|- Waiting for pods in namespace karavi to be ready                 Success

Release "karavi-observability" has been upgraded. Happy Helming!
NAME: karavi-observability
LAST DEPLOYED: Fri Jan  7 12:49:31 2022
NAMESPACE: karavi
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
CSM Topology
  The CSM Topology deployment has been successfully installed.


  The CSM Topology service can be accessed at the following URL from within the Kubernetes cluster: https://karavi-topology.karavi.svc.cluster.local

CSM Metrics for PowerFlex

  The CSM Metrics for PowerFlex deployment has been successfully installed.

  Provisioner Names: csi-vxflexos.dellemc.com
  Prometheus Scrape Target:
    From inside the Kubernetes cluster: otel-collector:8443

CSM Metrics for PowerStore

  The CSM Metrics for PowerStore deployment has been successfully installed.

  Provisioner Names: csi-powerstore.dellemc.com
  Prometheus Scrape Target:
    From inside the Kubernetes cluster: otel-collector:8443

- Upgrade performed from v1.0.0 to v1.0.1 using the offline installer script:

helm upgrade --version 1.0.1  karavi-observability dell/karavi-observability -n karavi
Release "karavi-observability" has been upgraded. Happy Helming!
NAME: karavi-observability
LAST DEPLOYED: Fri Jan  7 15:35:39 2022
NAMESPACE: karavi
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
CSM Topology
  The CSM Topology deployment has been successfully installed.


  The CSM Topology service can be accessed at the following URL from within the Kubernetes cluster: https://karavi-topology.karavi.svc.cluster.local

CSM Metrics for PowerFlex

  The CSM Metrics for PowerFlex deployment has been successfully installed.

  Provisioner Names: csi-vxflexos.dellemc.com
  Prometheus Scrape Target:
    From inside the Kubernetes cluster: otel-collector:8443

CSM Metrics for PowerStore

  The CSM Metrics for PowerStore deployment has been successfully installed.

  Provisioner Names: csi-powerstore.dellemc.com
  Prometheus Scrape Target:
    From inside the Kubernetes cluster: otel-collector:8443