### PR TITLE
add PV/PVC namespace mapping

### DIFF
--- a/grafana/dashboards/powerflex/volume_io_metrics.json
+++ b/grafana/dashboards/powerflex/volume_io_metrics.json
@@ -68,7 +68,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerflex_volume_read_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",  MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_read_iops_per_second{PlotWithMean=~ \"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",  MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
+          "expr": "powerflex_volume_read_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",  MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_read_iops_per_second{PlotWithMean=~ \"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",  MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{VolumeName}}",
           "refId": "A"
@@ -173,7 +173,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerflex_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
+          "expr": "powerflex_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{VolumeName}}",
           "refId": "A"
@@ -276,7 +276,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerflex_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
+          "expr": "powerflex_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{VolumeName}}",
           "refId": "A"
@@ -378,7 +378,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerflex_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
+          "expr": "powerflex_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{VolumeName}}",
           "refId": "A"
@@ -480,7 +480,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerflex_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
+          "expr": "powerflex_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{VolumeName}}",
           "refId": "A"
@@ -582,7 +582,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerflex_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
+          "expr": "powerflex_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"} and topk($TopX, avg_over_time(powerflex_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\",VolumeName=~\"$VolumeName\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\", MappedNodeIDs=~\"(.*__)($MappedNodeIDs)(__.*)\",MappedNodeIPs=~\"(.*__)($MappedNodeIPs)(__.*)\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{VolumeName}}",
           "refId": "A"

--- a/grafana/dashboards/powerstore/filesystem_io_metrics.json
+++ b/grafana/dashboards/powerstore/filesystem_io_metrics.json
@@ -69,7 +69,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "powerstore_filesystem_read_iops_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_filesystem_read_iops_per_second{PlotWithMean=~ \"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+            "expr": "powerstore_filesystem_read_iops_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_filesystem_read_iops_per_second{PlotWithMean=~ \"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
             "interval": "",
             "legendFormat": "{{PersistentVolumeName}}",
             "refId": "A"
@@ -177,7 +177,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "powerstore_filesystem_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_filesystem_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+            "expr": "powerstore_filesystem_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_filesystem_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
             "interval": "",
             "legendFormat": "{{PersistentVolumeName}}",
             "refId": "A"
@@ -280,7 +280,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "powerstore_filesystem_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_filesystem_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+            "expr": "powerstore_filesystem_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_filesystem_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
             "interval": "",
             "legendFormat": "{{PersistentVolumeName}}",
             "refId": "A"
@@ -382,7 +382,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "powerstore_filesystem_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_filesystem_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+            "expr": "powerstore_filesystem_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_filesystem_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
             "interval": "",
             "legendFormat": "{{PersistentVolumeName}}",
             "refId": "A"
@@ -484,7 +484,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "powerstore_filesystem_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_filesystem_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+            "expr": "powerstore_filesystem_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_filesystem_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
             "interval": "",
             "legendFormat": "{{PersistentVolumeName}}",
             "refId": "A"
@@ -586,7 +586,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "powerstore_filesystem_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_filesystem_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+            "expr": "powerstore_filesystem_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_filesystem_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", FileSystemID=~\"$FileSystemID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
             "interval": "",
             "legendFormat": "{{PersistentVolumeName}}",
             "refId": "A"
@@ -747,6 +747,58 @@
           "name": "PVName",
           "options": [],
           "query": "label_values(powerstore_filesystem_read_bw_megabytes_per_second,PersistentVolumeName)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "Prometheus",
+          "definition": "label_values(powerstore_filesystem_read_bw_megabytes_per_second,PersistentVolumeClaimName)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "PVC Name",
+          "multi": true,
+          "name": "PersistentVolumeClaimName",
+          "options": [],
+          "query": "label_values(powerstore_filesystem_read_bw_megabytes_per_second,PersistentVolumeClaimName)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "Prometheus",
+          "definition": "label_values(powerstore_filesystem_read_bw_megabytes_per_second,Namespace)",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Namespace",
+          "multi": true,
+          "name": "Namespace",
+          "options": [],
+          "query": "label_values(powerstore_filesystem_read_bw_megabytes_per_second,Namespace)",
           "refresh": 2,
           "regex": "",
           "skipUrlSync": false,

--- a/grafana/dashboards/powerstore/volume_io_metrics.json
+++ b/grafana/dashboards/powerstore/volume_io_metrics.json
@@ -69,7 +69,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerstore_volume_read_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_volume_read_iops_per_second{PlotWithMean=~ \"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+          "expr": "powerstore_volume_read_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_read_iops_per_second{PlotWithMean=~ \"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\", PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{PersistentVolumeName}}",
           "refId": "A"
@@ -174,7 +174,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerstore_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+          "expr": "powerstore_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_write_iops_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{PersistentVolumeName}}",
           "refId": "A"
@@ -277,7 +277,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerstore_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+          "expr": "powerstore_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_read_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{PersistentVolumeName}}",
           "refId": "A"
@@ -379,7 +379,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerstore_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+          "expr": "powerstore_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_write_latency_milliseconds{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{PersistentVolumeName}}",
           "refId": "A"
@@ -481,7 +481,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerstore_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+          "expr": "powerstore_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_read_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{PersistentVolumeName}}",
           "refId": "A"
@@ -583,7 +583,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "powerstore_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"} and topk($TopX, avg_over_time(powerstore_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}[$TimeFrame]))",
+          "expr": "powerstore_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_write_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
           "interval": "",
           "legendFormat": "{{PersistentVolumeName}}",
           "refId": "A"
@@ -744,6 +744,58 @@
         "name": "PVName",
         "options": [],
         "query": "label_values(powerstore_volume_read_bw_megabytes_per_second,PersistentVolumeName)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(powerstore_volume_read_bw_megabytes_per_second,PersistentVolumeClaimName)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "PVC Name",
+        "multi": true,
+        "name": "PersistentVolumeClaimName",
+        "options": [],
+        "query": "label_values(powerstore_volume_read_bw_megabytes_per_second,PersistentVolumeClaimName)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(powerstore_volume_read_bw_megabytes_per_second,Namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": true,
+        "name": "Namespace",
+        "options": [],
+        "query": "label_values(powerstore_volume_read_bw_megabytes_per_second,Namespace)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
# Description
1. PowerStore: add PV/PVC namespace mapping in 'PowerStore Volume IO metrics' and 'PowerStore Filesystem IO Metrics'
2. PowerFlex: add PV/PVC namespace mapping in 'Volume IO Metrics'

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/204|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have made corresponding changes to the documentation
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Test A
Manual:
![image](https://user-images.githubusercontent.com/63342088/179518436-4d357a7b-d4b7-4029-a480-336cebf79061.png)
![image](https://user-images.githubusercontent.com/63342088/179518459-0087ca20-bd2a-4c59-ab6b-c3568573b1b2.png)
![image](https://user-images.githubusercontent.com/63342088/179518479-38ad7e24-6ac1-414f-b625-78fcb831a809.png)

- [ ] Test B
