### PR TITLE
Reorganize columns in the topology dashboard

### DIFF
--- a/grafana/dashboards/powerstore/filesystem_io_metrics.json
+++ b/grafana/dashboards/powerstore/filesystem_io_metrics.json
@@ -815,15 +815,15 @@
           "auto_min": "10s",
           "current": {
             "selected": false,
-            "text": "2",
-            "value": "2"
+            "text": "10",
+            "value": "10"
           },
           "hide": 0,
           "label": "Ranking",
           "name": "TopX",
           "options": [
             {
-              "selected": true,
+              "selected": false,
               "text": "2",
               "value": "2"
             },
@@ -833,7 +833,7 @@
               "value": "5"
             },
             {
-              "selected": false,
+              "selected": true,
               "text": "10",
               "value": "10"
             },

--- a/grafana/dashboards/powerstore/volume_io_metrics.json
+++ b/grafana/dashboards/powerstore/volume_io_metrics.json
@@ -812,15 +812,15 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "10",
+          "value": "10"
         },
         "hide": 0,
         "label": "Ranking",
         "name": "TopX",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "2",
             "value": "2"
           },
@@ -830,7 +830,7 @@
             "value": "5"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "10",
             "value": "10"
           },

--- a/grafana/dashboards/topology/topology.json
+++ b/grafana/dashboards/topology/topology.json
@@ -161,7 +161,7 @@
           "hide": false,
           "rawQuery": false,
           "refId": "A",
-          "target": "{\n   \"Storage System\":\"$StorageSystem\",\n   \"Namespace\":\"$Namespace\",\n   \"Protocol\":\"$Protocol\",\n   \"CSI Driver\":\"$CSIDriver\",\n   \"Status\":\"$Status\",\n   \"Storage Pool\":\"$StoragePool\"\n}",
+          "target": "{\n   \"Storage System\":\"$StorageSystem\",\n   \"Namespace\":\"$Namespace\",\n   \"Protocol\":\"$Protocol\",\n   \"Storage Class\":\"$StorageClass\",\n   \"Status\":\"$Status\",\n   \"Storage Pool\":\"$StoragePool\"\n}",
           "type": "table"
         }
       ],
@@ -199,6 +199,31 @@
       "timeShift": null,
       "title": "CSI Driver Topologies",
       "transform": "table",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "CSI Driver": true
+            },
+            "indexByName": {
+              "CSI Driver": 11,
+              "Created": 6,
+              "Namespace": 0,
+              "Persistent Volume": 2,
+              "Persistent Volume Claim": 1,
+              "Protocol": 8,
+              "Provisioned Size": 4,
+              "Status": 5,
+              "Storage Class": 3,
+              "Storage Pool": 9,
+              "Storage System": 7,
+              "Storage System Volume Name": 10
+            },
+            "renameByName": {}
+          }
+        }
+      ],
       "type": "briangann-datatable-panel"
     }
   ],
@@ -216,32 +241,6 @@
           "value": [
             "$__all"
           ]
-        },
-        "datasource": "Karavi-Topology",
-        "definition": "Storage System",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Storage System",
-        "multi": true,
-        "name": "StorageSystem",
-        "options": [],
-        "query": "Storage System",
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
         },
         "datasource": "Karavi-Topology",
         "definition": "Namespace",
@@ -270,14 +269,14 @@
           "value": "$__all"
         },
         "datasource": "Karavi-Topology",
-        "definition": "Protocol",
+        "definition": "Storage Class",
         "hide": 0,
         "includeAll": true,
-        "label": "Protocol",
+        "label": "Storage Class",
         "multi": true,
-        "name": "Protocol",
+        "name": "StorageClass",
         "options": [],
-        "query": "Protocol",
+        "query": "Storage Class",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -322,14 +321,40 @@
           "value": "$__all"
         },
         "datasource": "Karavi-Topology",
-        "definition": "CSI Driver",
+        "definition": "Storage System",
         "hide": 0,
         "includeAll": true,
-        "label": "CSI Driver",
+        "label": "Storage System",
         "multi": true,
-        "name": "CSIDriver",
+        "name": "StorageSystem",
         "options": [],
-        "query": "CSI Driver",
+        "query": "Storage System",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "Karavi-Topology",
+        "definition": "Protocol",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Protocol",
+        "multi": true,
+        "name": "Protocol",
+        "options": [],
+        "query": "Protocol",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
# Description
1. Reorganize columns in the topology table:
  - The order of columns would be :
     Namespace > PVC > PV > StorageClass > Size > Status > Created > Storage System > Protocol > Pool > Volume
  - "not expand" the CSI Driver
2. Increase default ranking value to 10 in PowerStore IO metrics dashboard

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/401|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have made corresponding changes to the documentation
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Test A
Manual:
![image](https://user-images.githubusercontent.com/63342088/182529530-1057cc1b-dfee-4fdd-ab72-92b6c306d202.png)
![image](https://user-images.githubusercontent.com/63342088/182531111-04fde8e6-ea6c-4a3e-accf-1e8b28cfd868.png)
![image](https://user-images.githubusercontent.com/63342088/182531305-bec8f0b0-c430-4333-ae69-7462b9f6c05d.png)


