### PR TITLE
Fix issues in karavi-observability-install.sh

### DIFF
--- a/installer/common.sh
+++ b/installer/common.sh
@@ -115,3 +115,29 @@ function run_command() {
   fi
   return $RC
 }
+
+function check_versions_lower(){
+  if [[ $1 == $2 ]]; then
+    return 1
+  else
+    low=$(echo -e "$1\n$2" | sort --version-sort | head --lines=1)
+    if [[ $low == $1 ]]; then
+      return 0
+    else
+      return 1
+    fi
+  fi
+}
+
+function check_versions_greater(){
+  if [[ $1 == $2 ]]; then
+    return 1
+  else
+    low=$(echo -e "$1\n$2" | sort --version-sort | head --lines=1)
+    if [[ $low == $2 ]]; then
+      return 0
+    else
+      return 1
+    fi
+  fi
+}

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -368,7 +368,7 @@ function verify_karavi_observability() {
     return
   fi
   verify_k8s_versions "1.22" "1.24"
-  verify_openshift_versions "4.8" "4.9" "4.10"
+  verify_openshift_versions "4.8" "4.10"
   verify_helm_3
 }
 
@@ -387,9 +387,11 @@ function verify_k8s_versions() {
   log arrow
   log smart_step "Verifying minimum Kubernetes version" "small"
   error=0
-  if [[ ${V} < ${MIN} ]]; then
+
+  check_versions_lower ${V} ${MIN}
+  if [[ $? == "0" ]]; then
     error=1
-    step_error "Kubernetes version, ${V}, is too old. Minimum required version is: ${MIN}"
+    log step_warning "Kubernetes version, ${V}, is too old. Minimum required version is: ${MIN}"
   fi
   check_error error
 
@@ -397,9 +399,11 @@ function verify_k8s_versions() {
   log arrow
   log smart_step "Verifying maximum Kubernetes version" "small"
   error=0
-  if [[ ${V} > ${MAX} ]]; then
+
+  check_versions_greater ${V} ${MAX}
+  if [[ $? == "0" ]]; then
     error=1
-    step_warning "Kubernetes version, ${V}, is newer than has been tested. Latest tested version is: ${MAX}"
+    log step_warning "Kubernetes version, ${V}, is newer than has been tested. Latest tested version is: ${MAX}"
   fi
   check_error error
 
@@ -416,13 +420,16 @@ function verify_openshift_versions() {
   local MIN=${1}
   local MAX=${2}
   local V=$(OpenShiftVersion)
+
   # check minimum
   log arrow
   log smart_step "Verifying minimum OpenShift version" "small"
   error=0
-  if [[ ${V} < ${MIN} ]]; then
+
+  check_versions_lower ${V} ${MIN}
+  if [[ $? == "0" ]]; then
     error=1
-    step_error "OpenShift version, ${V}, is too old. Minimum required version is: ${MIN}"
+    log step_warning "OpenShift version, ${V}, is too old. Minimum required version is: ${MIN}"
   fi
   check_error error
 
@@ -430,9 +437,11 @@ function verify_openshift_versions() {
   log arrow
   log smart_step "Verifying maximum OpenShift version" "small"
   error=0
-  if [[ ${V} > ${MAX} ]]; then
+
+  check_versions_greater ${V} ${MAX}
+  if [[ $? == "0" ]]; then
     error=1
-    step_warning "OpenShift version, ${V}, is newer than has been tested. Latest tested version is: ${MAX}"
+    log step_warning "OpenShift version, ${V}, is newer than has been tested. Latest tested version is: ${MAX}"
   fi
   check_error error
 }
@@ -443,7 +452,7 @@ function verify_helm_3() {
   error=0
   # Check helm installer version
   helm --help >&/dev/null || {
-    step_error "helm is required for installation"
+    log step_warning "helm is required for installation"
     log step_failure
     return
   }
@@ -451,7 +460,7 @@ function verify_helm_3() {
   run_command helm version | grep "v3." --quiet
   if [ $? -ne 0 ]; then
     error=1
-    step_error "Driver installation is supported only using helm 3"
+    log step_warning "Driver installation is supported only using helm 3"
   fi
   check_error error
 }


### PR DESCRIPTION
# Description

Fix some issues in karavi-observability-install.sh:
- add log prior to step_warning
- use step_warning instead of step_error, which is undefined
- fix k8s and openshift version check logic

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/479 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have made corresponding changes to the documentation
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manually run karavi-observability-install.sh
``` bash
./karavi-observability-install.sh install --namespace karavi --values myvalues.yaml
---------------------------------------------------------------------------------
> Installing Karavi Observability in namespace karavi on 1.23
---------------------------------------------------------------------------------
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/yuocp/auth/kubeconfig
|
|- Karavi Observability is not installed                            Success
|
|- Karavi Authorization will not be enabled during installation
|
|- Verifying OpenShift versions
  |
  |--> Verifying minimum OpenShift version                          Success
  |
  |--> Verifying maximum OpenShift version                          Success
|
|- Verifying helm version                                           WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/yulanocp410/auth/kubeconfig
Success
|
|- Configure helm chart repository
  |
  |--> Adding helm repository https://dell.github.io/helm-charts    Success
  |
  |--> Updating helm repositories                                   Success
Namespace karavi already exists
|
|- CSI Driver for PowerFlex is not installed                        Success
|
|- CSI Driver for PowerStore is not installed                       Success
|
|- CSI Driver for PowerScale is installed                           Success
Certmanager CRDs are already installed
|
|- Installing Karavi Observability helm chart                       Success
|
|- Waiting for pods in namespace karavi to be ready                 Success

WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/yuocp/auth/kubeconfig
NAME: karavi-observability
LAST DEPLOYED: Tue Oct 25 23:21:14 2022
NAMESPACE: karavi
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
CSM Topology
  The CSM Topology deployment has been successfully installed.


  The CSM Topology service can be accessed at the following URL from within the Kubernetes cluster: https://karavi-topology.karavi.svc.cluster.local





CSM Metrics for PowerScale

  The CSM Metrics for PowerScale deployment has been successfully installed.

  Provisioner Names: csi-isilon.dellemc.com
  Prometheus Scrape Target:
    From inside the Kubernetes cluster: otel-collector:8443
```
