### PR TITLE
Updated in the installation Script 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,4 +27,4 @@
 # Forrest Xia (forrestxia)
 
 # for all files:
-* @gallacher @tdawe @alikdell @atye @hoppea2 @coulof @shaynafinocchiaro @sharmilarama @EvgenyUglov @bjiang27 @Sahiba-Gupta @arnchiequ-dell @jackieung-dell @taohe1012 @P-Cao @baoy1 @YianZong @forrestxia
+* @gallacher @tdawe @alikdell @atye @hoppea2 @coulof @shaynafinocchiaro @sharmilarama @EvgenyUglov @bjiang27 @Sahiba-Gupta @arnchiequ-dell @jackieung-dell @taohe1012 @P-Cao @baoy1 @YianZong @forrestxia  @donatwork @harshaatdell @anandrajak1

--- a/installer/karavi-observability-install.sh
+++ b/installer/karavi-observability-install.sh
@@ -442,8 +442,8 @@ function verify_karavi_observability() {
     log info "Skipping verification of the environment"
     return
   fi
-  verify_k8s_versions "1.22" "1.26"
-  verify_openshift_versions "4.8" "4.11"
+  verify_k8s_versions "1.25" "1.27"
+  verify_openshift_versions "4.9" "4.12"
   verify_helm_3
 }
 


### PR DESCRIPTION
# Description
Updated in the installation script to support K8s 1.27 and openshift 4.12


| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/743|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have made corresponding changes to the documentation

# How Has This Been Tested?
Warning message was displayed when executing the script in latest K8s version 1.27
No warning message was displayed after updated the version in installation script

![image](https://github.com/dell/karavi-observability/assets/105747555/c4290c3e-38cf-474e-b543-c80e7413d006)
