### PR TITLE
Add Replication metrics support in Grafana Chart for csi-powerstore driver.

### DIFF
--- a/grafana/dashboards/powerstore/volume_io_metrics.json
+++ b/grafana/dashboards/powerstore/volume_io_metrics.json
@@ -635,6 +635,210 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {
+        "Average MirrorBW": "dark-red"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "powerstore_volume_mirror_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_mirror_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
+          "interval": "",
+          "legendFormat": "{{PersistentVolumeName}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(powerstore_volume_mirror_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)|No\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}) / count(powerstore_volume_mirror_bw_megabytes_per_second{PlotWithMean=~\"($ShowMean)|No\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"})",
+          "interval": "",
+          "legendFormat": "Average MirrorBW",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Volume Mirror Bandwidth (MB/s)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "Average DataRemaining": "dark-red"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "powerstore_volume_data_remaining_megabytes{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"} and topk($TopX, avg_over_time(powerstore_volume_data_remaining_megabytes{PlotWithMean=~\"($ShowMean)\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\", PersistentVolumeClaimName=~\"$PersistentVolumeClaimName\",Namespace=~\"$Namespace\"}[$TimeFrame]))",
+          "interval": "",
+          "legendFormat": "{{PersistentVolumeName}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(powerstore_volume_data_remaining_megabytes{PlotWithMean=~\"($ShowMean)|No\", VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"}) / count(powerstore_volume_data_remaining_megabytes{PlotWithMean=~\"($ShowMean)|No\",VolumeID=~\"$VolumeID\", ArrayID=~\"$ArrayID\",PersistentVolumeName=~\"$PVName\"})",
+          "interval": "",
+          "legendFormat": "Average DataRemaining",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Volume Replication Data Remaining(MB)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "5s",

--- a/grafana/dashboards/powerstore/volume_io_metrics.json
+++ b/grafana/dashboards/powerstore/volume_io_metrics.json
@@ -660,7 +660,7 @@
         "y": 16
       },
       "hiddenSeries": false,
-      "id": 10,
+      "id": 11,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -762,7 +762,7 @@
         "y": 16
       },
       "hiddenSeries": false,
-      "id": 10,
+      "id": 12,
       "legend": {
         "alignAsTable": true,
         "avg": true,


### PR DESCRIPTION
# Description
Add Replication metrics support in Grafana Chart for csi-powerstore driver.
Following metrics has been added:
* Volume Mirror Bandwidth
* Volume Replication Data Remaining

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1443 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Verified UI changes.
 
![Screenshot 2024-10-07 172325](https://github.com/user-attachments/assets/46e8489b-82aa-44b9-8e81-56914cab765b)
![Screenshot 2024-10-07 165031](https://github.com/user-attachments/assets/e0a130fd-1453-4c64-8804-72c403d58735)

