### PR TITLE
Update offline script to ignore comments

### DIFF
--- a/installer/offline-installer.sh
+++ b/installer/offline-installer.sh
@@ -57,7 +57,7 @@ create_bundle() {
     run_command "helm pull ${CHARTNAME} --untar --untardir ${DISTDIR}/${HELMBACKUPDIR}"
 
     # search for all images from the values.yaml files that were contained in the Helm chart
-    find ${DISTDIR}/${HELMBACKUPDIR} -name "values.yaml" -type f -exec egrep -oh "image: (.+)" {} \; | awk '{print $2}' > ${DISTDIR}/images.txt
+    find ${DISTDIR}/${HELMBACKUPDIR} -name "values.yaml" -type f -exec grep -v '^[[:space:]]*#' {} \; | egrep -oh "image: (.+)" | awk '{print $2}' > ${DISTDIR}/images.txt
 
     status "Downloading and saving Docker images"
     while read line; do


### PR DESCRIPTION
# Description
Offline script currently, when extracting images to be downloaded from the Observability values file, is adding incorrect entries as the pattern in some of the commented lines is matching the pattern mentioned in find command. Updated the find command to ignore commented lines while matching pattern

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1917 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have made corresponding changes to the documentation
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Tested downloading the images as per the steps mentioned in the documentation https://dell.github.io/csm-docs/v3/deployment/offline/modules/

Testing screenshots of downloading and pushing the images to the private registry:

![image](https://github.com/user-attachments/assets/3bf57f74-4633-4da1-a8d8-eb821bacb1ac)

![image](https://github.com/user-attachments/assets/1ec68e92-bc06-497a-9603-36868472556a)

![image](https://github.com/user-attachments/assets/21b2aad5-4366-49cd-bfa5-4d67a5e9aa63)